### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Dicom fields are separated into different groups. Each groups will be anonymized
 # How to build it ?
 
 The sources files can be packaged by using:
-`python .\setup.py bdist_wheel`
+`python ./setup.py bdist_wheel`
 
 This command will generate a wheel package in `dist` folder which can be then installed as a python package using
-`pip install .\dist\DicomAnonymizer-0.0.1-py2.py3-none-any.whl`
+`pip install ./dist/dicom_anonymizer-1.0.7-py2.py3-none-any.whl`
 
 Installing this package will also install an executable named `dicom-anonymizer`. In order to use it, please refer to the next section.
 


### PR DESCRIPTION
(1) Changed path separator direction to forward slash. Windows accepts both directions, but Unix only accepts `/`, so this way the instructions work for both.

(2) Changed filename to match current reality.