### PR TITLE
ignore non-iterable items

### DIFF
--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -106,8 +106,11 @@ def deleteElement(dataset, element):
         replaceElementDate(element)
     elif element.VR == 'SQ':
         for subDataset in element.value:
-            for subElement in subDataset.elements():
-                deleteElement(subDataset, subElement)
+            try:
+                for subElement in subDataset.elements():
+                    deleteElement(subDataset, subElement)
+            except AttributeError:
+                pass
     else:
         del dataset[element.tag]
 


### PR DESCRIPTION
This is a band-aid patch to ignore non-iterable items, as described in #7 .

**There is probably a better way to do this -- you might want to think about what way that is instead of merging this. This just papers over whatever the underlying problem is.**