### PR TITLE
Prettier printing of tags when "Cannot get element from tag"

### DIFF
--- a/dicomanonymizer/format_tag.py
+++ b/dicomanonymizer/format_tag.py
@@ -15,7 +15,7 @@ def hex_to_string(x):
     num_zeroes = 4 - len(right)
     return left + ('0'*num_zeroes) + right
 
-def tag_to_hex_string(tag):
+def tag_to_hex_strings(tag):
     """
     Convert a tag tuple to a tuple of full hex number strings.
 

--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -5,6 +5,7 @@ import pydicom
 from random import randint
 
 from .dicomfields import *
+from .format_tag import tag_to_hex_strings
 
 dictionary = {}
 
@@ -353,7 +354,7 @@ def get_private_tags(anonymization_actions: dict, dataset: pydicom.Dataset) -> L
         try:
             element = dataset.get(tag)
         except:
-            print("Cannot get element from tag: ", tag)
+            print("Cannot get element from tag: ", tag_to_hex_strings(tag))
 
         if element and element.tag.is_private:
             private_tags.append(get_private_tag(dataset, tag))
@@ -381,7 +382,7 @@ def anonymize_dataset(dataset: pydicom.Dataset, extra_anonymization_rules: dict 
         try:
             element = dataset.get(tag)
         except:
-            print("Cannot get element from tag: ", tag)
+            print("Cannot get element from tag: ", tag_to_hex_strings(tag))
 
         if element and element.tag.is_private:
             private_tags.append(get_private_tag(dataset, tag))

--- a/dicomanonymizer/tag_to_hex_string.py
+++ b/dicomanonymizer/tag_to_hex_string.py
@@ -1,0 +1,25 @@
+"""
+Utility for printing the tags in the original hex format.
+"""
+
+def hex_to_string(x):
+    """
+    Convert a tag number to it's original hex string.
+
+    E.g. if a tag has the hex number 0x0008, it becomes 8,
+    and we then convert it back to 0x0008 (as a string).
+    """
+    x = str(hex(x))
+    left = x[:2]
+    right = x[2:]
+    num_zeroes = 4 - len(right)
+    return left + ('0'*num_zeroes) + right
+
+def tag_to_hex_string(tag):
+    """
+    Convert a tag tuple to a tuple of full hex number strings.
+
+    E.g. (0x0008, 0x0010) is evaluated as (8, 16) by python. So
+    we convert it back to a string '(0x0008, 0x0010)' for pretty printing.
+    """
+    return tuple([hex_to_string(tag_element) for tag_element in tag])


### PR DESCRIPTION
It seems more meaningful to print the tag formatted as the hex number we use to specify it with in the first place.
This might not be the most elegant solution to convert it, but it seems to work fine.

Btw. could the error message "Cannot get element from tag" be more specific? Is it because the tag is not in the dicom file? 

Best,
Ludvig