### PR TITLE
Fix anonymization of meta info header + disable check for 4-indices tags

### DIFF
--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -378,9 +378,18 @@ def anonymize_dataset(dataset: pydicom.Dataset, extra_anonymization_rules: dict 
     private_tags = []
 
     for tag, action in current_anonymization_actions.items():
-        action(dataset, tag)
+        # The meta header information is located in the `file_meta` dataset
+        # For tags with tag group `0x0002` we thus apply the action to the `file_meta` dataset
+        if tag[0] == 0x0002:
+            # Apply rule to meta information header
+            action(dataset.file_meta, tag)
+        else:
+            action(dataset, tag)
         try:
-            element = dataset.get(tag)
+            # `get()` does not accept the 4-indices tags in `dicomfields.py`
+            # so only make this check with <=2-indices tags
+            if len(tag) <= 2:
+                element = dataset.get(tag)
         except:
             print("Cannot get element from tag: ", tag_to_hex_strings(tag))
 

--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -387,7 +387,9 @@ def anonymize_dataset(dataset: pydicom.Dataset, extra_anonymization_rules: dict 
             action(dataset, tag)
         try:
             # `get()` does not accept the 4-indices tags in `dicomfields.py`
-            # so only make this check with <=2-indices tags
+            # so only attempt to get the tag with <=2-indices tags
+            # otherwise set to None
+            element = None
             if len(tag) <= 2:
                 element = dataset.get(tag)
         except:


### PR DESCRIPTION
1) Currently, tags in the meta information header (`0x0002` group) are not applied. This fixes that by applying the action to the `file_meta` dataset instead.

2) In dicomfields.py there are 3 tags made up of 4 ints / hex numbers. `dataset.get()` only works with 2-indices tags, so that lookup always fail (at least for me). This only performs the `get()` call for tags with 1 or 2 indices. I used `<=2` as I believe `get()` accepts a string as well.  See also https://github.com/KitwareMedical/dicom-anonymizer/issues/17 