### PR TITLE
Fix the repeating groups anonymization

### DIFF
--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -384,7 +384,7 @@ def anonymize_dataset(dataset: pydicom.Dataset, extra_anonymization_rules: dict 
 
         def range_callback(dataset, data_element):
             if data_element.tag.group & tag[2] == tag[0] and data_element.tag.element & tag[3] == tag[1]:
-                action(dataset, tag)
+                action(dataset, (data_element.tag.group, data_element.tag.element))
 
         element = None
 


### PR DESCRIPTION
Repeating groups are a type of DICOM tags that lay over a range of
tag identifiers.
In the case of a repeating group tag, assert the tag is within the
desired range, then anonymize it according to its tag identifier.

Fixes https://github.com/KitwareMedical/dicom-anonymizer/issues/25