### PR TITLE
Joining of paths resulted in error

### DIFF
--- a/dicomanonymizer/anonymizer.py
+++ b/dicomanonymizer/anonymizer.py
@@ -27,7 +27,7 @@ def anonymize(input_path: str, output_path: str, anonymization_actions: dict, de
     if os.path.isdir(output_path):
         output_folder = output_path
         if input_folder == '':
-            output_path = output_folder + os.path.basename(input_path)
+            output_path = os.path.join(output_folder, os.path.basename(input_path))
 
     if input_folder != '' and output_folder == '':
         print('Error, please set a correct output folder path')


### PR DESCRIPTION
Concatenating causes problems when no trailing slash was included in the path.