### PR TITLE
Fixed UID replacement and added support for multi-value UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dicom fields are separated into different groups. Each groups will be anonymized
 | D_TAGS | replace | Replace with a non-zero length value that may be a dummy value and consistent with the VR** |
 | Z_TAGS | empty | Replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR** |
 | X_TAGS | delete | Completely remove the tag |
-| U_TAGS | replace_UID | Replace all UID's number with a random one in order to keep consistent. Same UID will have the same replaced value |
+| U_TAGS | replace_UID | Replace all UID's random ones. Same UID will have the same replaced value |
 | Z_D_TAGS | empty_or_replace | Replace with a non-zero length value that may be a dummy value and consistent with the VR** |
 | X_Z_TAGS | delete_or_empty | Replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR** |
 | X_D_TAGS | delete_or_replace | Replace with a non-zero length value that may be a dummy value and consistent with the VR** |

--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -2,7 +2,7 @@ import re
 from typing import List
 
 import pydicom
-from random import randint
+from pydicom.uid import generate_uid
 
 from .dicomfields import *
 from .format_tag import tag_to_hex_strings
@@ -36,13 +36,12 @@ def regexp(options: dict):
 
 def replace_element_UID(element):
     """
-    Keep char value but replace char number with random number
+    Replace UID with random UID
     The replaced value is kept in a dictionary link to the initial element.value in order to automatically
     apply the same replaced value if we have an other UID with the same value
     """
     if element.value not in dictionary:
-        new_chars = [str(randint(0, 9)) if char.isalnum() else char for char in element.value]
-        dictionary[element.value] = ''.join(new_chars)
+        dictionary[element.value] = generate_uid(None)
     element.value = dictionary.get(element.value)
 
 

--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -33,7 +33,7 @@ def regexp(options: dict):
 
 # Default anonymization functions
 
-def get_new_UID(old_uid: str) -> str:
+def get_UID(old_uid: str) -> str:
     """
     Lookup new UID in cached dictionary or create new one if none found
     """
@@ -52,9 +52,9 @@ def replace_element_UID(element):
     if type(element.value) == MultiValue:
         # Example of multi-value UID situation: IrradiationEventUID, (0008,3010) 
         for k, v in enumerate(element.value):
-            element.value[k] = get_new_UID(v)
+            element.value[k] = get_UID(v)
     else:
-        element.value = get_new_UID(element.value)
+        element.value = get_UID(element.value)
 
 def replace_element_date(element):
     """
@@ -102,7 +102,7 @@ def replace_element(element):
     elif element.VR == 'SQ':
         for sub_dataset in element.value:
             for sub_element in sub_dataset.elements():
-                replace_element(sub_element)
+                replace_element(sub_element)                
     elif element.VR == 'DT':
         replace_element_date_time(element)
     else:

--- a/dicomanonymizer/simpledicomanonymizer.py
+++ b/dicomanonymizer/simpledicomanonymizer.py
@@ -102,7 +102,7 @@ def replace_element(element):
     elif element.VR == 'SQ':
         for sub_dataset in element.value:
             for sub_element in sub_dataset.elements():
-                replace_element(sub_element)                
+                replace_element(sub_element)
     elif element.VR == 'DT':
         replace_element_date_time(element)
     else:


### PR DESCRIPTION
While anonymizing a dataset that had (0008,1130), I got this error message:
```
simpledicomanonymizer.py", line 43, in replace_element_UID
    if element.value not in dictionary:
TypeError: unhashable type: 'MultiValue'
```
I have now added support for multi-value UIDs.
Also found another problem when some of the replaced UIDs were flagged as invalid. This can occur when a digit following '.' is a 0 with more digits to follow. See https://dicom.nema.org/dicom/2013/output/chtml/part05/chapter_9.html, first item under Sec 9.1.

I found that pydicom already provides a method to create UIDs, hence using that now.