### PR TITLE
add workflow to automatically publish on pip

### DIFF
--- a/.github/publish-on-pypi.yml
+++ b/.github/publish-on-pypi.yml
@@ -1,0 +1,42 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on: 
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Adding a workflow to automatically push the build (both the wheel and sdist) to pip on tag creation. It needs the secret variable `PYPI_API_TOKEN` to be present in the repository's settings (see [this page](https://dev.to/iamtekson/publish-package-to-pypi-and-release-new-version-using-github-actions-108k) for details).

<img width="248" alt="image" src="https://user-images.githubusercontent.com/11719673/229192143-c548fe0c-1188-4393-ba43-2e17faf0c3bc.png">
