### PR TITLE
ENH: Restore limited Python3.6 support

### DIFF
--- a/dicomanonymizer/anonymizer.py
+++ b/dicomanonymizer/anonymizer.py
@@ -1,6 +1,11 @@
+import sys
+if sys.version_info >= (3,8):
+    import importlib.metadata as metadata
+else:
+    import importlib_metadata as metadata
+
 import argparse
 import ast
-import importlib.metadata
 import json
 import os
 import sys
@@ -98,7 +103,7 @@ def generate_actions_dictionary(map_action_tag, defined_action_map = {}) -> dict
 
 
 def main(defined_action_map = {}):
-    version_info = importlib.metadata.version("dicom_anonymizer")
+    version_info = metadata.version("dicom_anonymizer")
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument('input', help='Path to the input dicom file or input directory which contains dicom files')
     parser.add_argument('output', help='Path to the output dicom file or output directory which will contains dicom files')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Program to anonymize dicom files with default and custom rules"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.6"
 classifiers = [
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+"""A setuptools based setup module.
+See:
+https://packaging.python.org/guides/distributing-packages-using-setuptools/
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+
+setup(
+    name='dicom_anonymizer',  # Required
+    version='1.0.12',  # Required
+
+    packages=find_packages(),  # Required
+
+    # Define an executable calls dicom-anonymizer from a specific file
+    entry_points={
+        'console_scripts': [
+            'dicom-anonymizer = dicomanonymizer.anonymizer:main'
+        ]
+    },
+
+    # This field lists other packages that your project depends on to run.
+    # Any package you put here will be installed by pip when your project is
+    # installed, so they must be valid existing projects.
+    #
+    # For an analysis of "install_requires" vs pip's requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=['pydicom', 'tqdm'],  # Optional
+)


### PR DESCRIPTION
Despite all my researches and tries, it seems Python3.6 cannot build the package without a setup.py file.
Also take into account the importlib_metadata name change.