### PR TITLE
IMP: Refactor CLI system

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Example 2: We just want to change the study date from 20080701 to 20080000, then
 python anonymizer.py InputFilePath OutputFilePath -t '(0x0008, 0x0020)' 'regexp' '0701$' '0000'
 ```
 
+Example 3: Change the tag value with an arbitrary value
+```python
+python anonymizer.py InputFilePath OutputFilePath -t '(0x0010, 0x0010)' 'replace_with_value' 'new_value'
+```
+
 
 ## Custom rules with dictionary file
 
@@ -257,14 +262,14 @@ You can also add `extra_anonymization_rules` as above:
 | empty | Replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR** |
 | delete | Completely remove the tag |
 | keep | Do nothing on the tag |
-| clean | Don't use it for now. This is not implemented |
 | replace_UID | Replace all UID's number with a random one in order to keep consistent. Same UID will have the same replaced value |
 | empty_or_replace | Replace with a non-zero length value that may be a dummy value and consistent with the VR** |
 | delete_or_empty | Replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR** |
 | delete_or_replace | Replace with a non-zero length value that may be a dummy value and consistent with the VR** |
 | deleteOrEmptyOrReplace | Replace with a non-zero length value that may be a dummy value and consistent with the VR** |
 | delete_or_empty_or_replace_UID | If it's a UID, then all numbers are randomly replaced. Else, replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR** |
-|regexp| These action is not a common action. It allows to use regexp to modify values|
+|regexp| Find a value in the tag using a regexp and replace it with an arbitrary value. See the examples in this file to learn how to use.|
+|replace_with_value| Replace the tag value with an arbitrary value. See the examples in this file to learn how to use.
 
 
 ** VR: Value Representation

--- a/dicomanonymizer/__init__.py
+++ b/dicomanonymizer/__init__.py
@@ -1,2 +1,2 @@
-from .simpledicomanonymizer import *
-from .anonymizer import anonymize
+from dicomanonymizer.simpledicomanonymizer import *  # noqa: F401, F403
+from dicomanonymizer.anonymizer import anonymize  # noqa: F401

--- a/dicomanonymizer/anonymizer.py
+++ b/dicomanonymizer/anonymizer.py
@@ -1,5 +1,5 @@
 import sys
-if sys.version_info >= (3,8):
+if sys.version_info >= (3, 8):
     import importlib.metadata as metadata
 else:
     import importlib_metadata as metadata
@@ -11,7 +11,7 @@ import os
 import sys
 import tqdm
 
-from .simpledicomanonymizer import *
+from dicomanonymizer.simpledicomanonymizer import anonymize_dicom_file, ActionsMapNameFunctions
 
 
 def isDICOMType(filePath):
@@ -73,50 +73,85 @@ def anonymize(input_path: str, output_path: str, anonymization_actions: dict, de
     progress_bar.close()
 
 
-def generate_actions_dictionary(map_action_tag, defined_action_map = {}) -> dict:
+def parse_tag_actions_arguments(t_arguments: list, new_anonymization_actions: dict):
     """
-    Generate a new dictionary which maps actions function to tags
+    Parse the -t arguments and mutates the new_anonymization_actions dict
 
-    :param map_action_tag: link actions to tags
-    :param defined_action_map: link action name to action function
+    :param t_arguments: The -t arguments as given by argparse
+    :param new_anonymization_actions: The dict containing the base anonymization actions. This will be mutated.
     """
-    generated_map = {}
-    cpt = 0
-    for tag in map_action_tag:
-        test = [tag]
-        action = map_action_tag[tag]
+    for current_tag_parameters in t_arguments:
+        nb_parameters = len(current_tag_parameters)
+        if nb_parameters < 2:
+            raise ValueError("-t parameters should always have 2 values: tag and action")
 
-        # Define the associated function to the tag
-        if callable(action):
-            action_function = action
-        else:
-            action_function = defined_action_map[action] if action in defined_action_map else eval(action)
+        tag = current_tag_parameters[0]
+        action_name = current_tag_parameters[1]
 
-        # Generate the map
-        if cpt == 0:
-            generated_map = generate_actions(test, action_function)
-        else:
-            generated_map.update(generate_actions(test, action_function))
-        cpt += 1
+        try:
+            action_object = ActionsMapNameFunctions[action_name].value
+        except KeyError:
+            raise ValueError(f"Action {action_name} is not recognized.")
 
-    return generated_map
+        action_arguments = current_tag_parameters[2:]
+
+        if len(action_arguments) != action_object.number_of_expected_arguments:
+            raise ValueError(f"Wrong number of arguments for action {action_name}: found {len(action_arguments)}")
+
+        action = action_object.function if not len(action_arguments) else action_object.function(action_arguments)
+        tag_list = [ast.literal_eval(tag)]
+
+        new_anonymization_actions.update({tag: action for tag in tag_list})
 
 
-def main(defined_action_map = {}):
+def parse_dictionary_argument(dictionary_argument, new_anonymization_actions):
+    """
+    Parse the --dictionary argument and mutates the new_anonymization_actions dict
+
+    :param dictionary_argument: The --dictionary argument as given by argparse
+    :param new_anonymization_actions: The dict containing the base anonymization actions. This will be mutated.
+    """
+    with open(dictionary_argument) as json_file:
+        data = json.load(json_file)
+        for tag, action_or_options in data.items():
+            if isinstance(action_or_options, dict):
+                try:
+                    action_name = action_or_options.pop('action')
+                except KeyError as e:
+                    raise ValueError(f"Missing field in tag {tag}: {e.args[0]}")
+                try:
+                    action_object = ActionsMapNameFunctions[action_name].value
+                except KeyError:
+                    raise ValueError(f"Action {action_name} is not recognized.")
+                if len(action_or_options) != action_object.number_of_expected_arguments:
+                    raise ValueError(
+                        f"Wrong number of arguments for action {action_name}: found {len(action_or_options)}")
+                action = action_object.function(action_or_options)
+            else:
+                try:
+                    action = ActionsMapNameFunctions[action_or_options].value.function
+                except KeyError:
+                    raise ValueError(f"Action {action_or_options} is not recognized.")
+
+            tag_list = [ast.literal_eval(tag)]
+            new_anonymization_actions.update({tag: action for tag in tag_list})
+
+
+def main():
     version_info = metadata.version("dicom_anonymizer")
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument('input', help='Path to the input dicom file or input directory which contains dicom files')
-    parser.add_argument('output', help='Path to the output dicom file or output directory which will contains dicom files')
-    parser.add_argument('-t', action='append', nargs='*', help='tags action : Defines a new action to apply on the tag.'\
-    '\'regexp\' action takes two arguments: '\
-        '1. regexp to find substring '\
-        '2. the string that will replace the previous found string')
-    parser.add_argument('-v',
-                        '--version',
-                        action='version',
-                        version=f'%(prog)s {version_info}')                        
-    parser.add_argument('--dictionary', action='store', help='File which contains a dictionary that can be added to the original one')
-    parser.add_argument('--keepPrivateTags', action='store_true', dest='keepPrivateTags', help='If used, then private tags won\'t be deleted')
+    parser.add_argument(
+        'output', help='Path to the output dicom file or output directory which will contains dicom files')
+    parser.add_argument(
+        '-t', action='append', nargs='*',
+        help='tags action : Defines a new action to apply on the tag.\'regexp\' action takes two arguments: '
+        '1. regexp to find substring 2. the string that will replace the previous found string')
+    parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {version_info}')
+    parser.add_argument('--dictionary', action='store',
+                        help='File which contains a dictionary that can be added to the original one')
+    parser.add_argument('--keepPrivateTags', action='store_true', dest='keepPrivateTags',
+                        help='If used, then private tags won\'t be deleted')
     parser.set_defaults(keepPrivateTags=False)
     args = parser.parse_args()
 
@@ -125,62 +160,16 @@ def main(defined_action_map = {}):
 
     # Create a new actions' dictionary from parameters
     new_anonymization_actions = {}
-    cpt = 0
     if args.t:
-        number_of_new_tags_actions = len(args.t)
-        if number_of_new_tags_actions > 0:
-            for i in range(number_of_new_tags_actions):
-                current_tag_parameters = args.t[i]
-
-                nb_parameters = len(current_tag_parameters)
-                if nb_parameters == 0:
-                    continue
-
-                options = None
-                action_name = current_tag_parameters[1]
-
-                # Means that we are in regexp mode
-                if nb_parameters == 4:
-                    options = {
-                        "find": current_tag_parameters[2],
-                        "replace": current_tag_parameters[3]
-                    }
-
-                tags_list = [ast.literal_eval(current_tag_parameters[0])]
-
-                action = eval(action_name)
-                # When generate_actions is called and we have options, we don't want use regexp
-                # as an action but we want to call it to generate a new method
-                if options is not None:
-                    action = action_name
-
-                if cpt == 0:
-                    new_anonymization_actions = generate_actions(tags_list, action, options)
-                else:
-                    new_anonymization_actions.update(generate_actions(tags_list, action, options))
-                cpt += 1
+        parse_tag_actions_arguments(args.t, new_anonymization_actions)
 
     # Read an existing dictionary
     if args.dictionary:
-        with open(args.dictionary) as json_file:
-            data = json.load(json_file)
-            for key, value in data.items():
-                action_name = value
-                options = None
-                if type(value) is dict:
-                    action_name = value['action']
-                    options = {
-                        "find": value['find'],
-                        "replace" : value['replace']
-                    }
-
-                l = [ast.literal_eval(key)]
-                action = defined_action_map[action_name] if action_name in defined_action_map else eval(action_name)
-                if cpt == 0:
-                    new_anonymization_actions = generate_actions(l, action, options)
-                else:
-                    new_anonymization_actions.update(generate_actions(l, action, options))
-                cpt += 1
+        parse_dictionary_argument(args.dictionary, new_anonymization_actions)
 
     # Launch the anonymization
     anonymize(input_path, output_path, new_anonymization_actions, not args.keepPrivateTags)
+
+
+if __name__ == '__main__':
+    main()

--- a/dicomanonymizer/format_tag.py
+++ b/dicomanonymizer/format_tag.py
@@ -2,6 +2,7 @@
 Utility for printing the tags in the original hex format.
 """
 
+
 def hex_to_string(x):
     """
     Convert a tag number to it's original hex string.
@@ -13,7 +14,8 @@ def hex_to_string(x):
     left = x[:2]
     right = x[2:]
     num_zeroes = 4 - len(right)
-    return left + ('0'*num_zeroes) + right
+    return left + ('0' * num_zeroes) + right
+
 
 def tag_to_hex_strings(tag):
     """

--- a/examples/anonymize_extra_rules.py
+++ b/examples/anonymize_extra_rules.py
@@ -1,5 +1,7 @@
 import argparse
-from dicomanonymizer import ALL_TAGS, anonymize, keep
+
+from dicomanonymizer.dicomfields import ALL_TAGS
+from dicomanonymizer import anonymize, keep
 
 
 def main():
@@ -25,7 +27,7 @@ def main():
     def set_date_to_year(dataset, tag):
         element = dataset.get(tag)
         if element is not None:
-            element.value = f"{element.value[:4]}0101" # YYYYMMDD format
+            element.value = f"{element.value[:4]}0101"  # YYYYMMDD format
 
     # ALL_TAGS variable is defined on file dicomfields.py
     # the 'keep' method is already defined into the dicom-anonymizer
@@ -33,7 +35,7 @@ def main():
     for i in ALL_TAGS:
         extra_anonymization_rules[i] = keep
 
-    extra_anonymization_rules[(0x0010, 0x0030)] = set_date_to_year # Patient's Birth Date
+    extra_anonymization_rules[(0x0010, 0x0030)] = set_date_to_year  # Patient's Birth Date
 
     # Launch the anonymization
     anonymize(

--- a/tests/test_anon.py
+++ b/tests/test_anon.py
@@ -7,7 +7,8 @@ from pydicom import dcmread
 from pydicom.config import settings, IGNORE
 from pydicom.data import get_testdata_files
 
-from dicomanonymizer import anonymize_dataset, dicomfields
+from dicomanonymizer.simpledicomanonymizer import anonymize_dataset
+from dicomanonymizer import dicomfields
 
 # Ignore warnings from pydicom validation
 settings.writing_validation_mode = IGNORE
@@ -40,7 +41,7 @@ def get_passing_files():
 @pytest.fixture(scope="module", params=get_passing_files())
 def orig_anon_dataset(request):
     orig_ds = dcmread(request.param)
-    orig_ds.filename = None # Non-None value causes warnings in copy(). Not needed for this testing
+    orig_ds.filename = None  # Non-None value causes warnings in copy(). Not needed for this testing
     anon_ds = orig_ds.copy()
     anonymize_dataset(anon_ds)
     return (orig_ds, anon_ds)

--- a/tests/test_anonymization_without_dicom.py
+++ b/tests/test_anonymization_without_dicom.py
@@ -1,6 +1,6 @@
 import pydicom
 
-from dicomanonymizer import anonymize_dataset
+from dicomanonymizer.simpledicomanonymizer import anonymize_dataset
 
 
 def test_anonymization_without_dicom_file():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,83 @@
+import pytest
+import pydicom
+import sys
+
+from unittest.mock import patch
+
+from dicomanonymizer.anonymizer import main
+from dicomanonymizer.simpledicomanonymizer import empty
+
+
+@pytest.fixture
+def a_simple_dataset():
+    dataset = pydicom.Dataset()
+    dataset.add_new((0x0010, 0x0010), "PN", "Test Name")
+    return dataset
+
+
+@pytest.fixture
+def an_anonymize_mock():
+    with patch("dicomanonymizer.anonymizer.anonymize") as anonymize_mock:
+        yield anonymize_mock
+
+
+def test_basic_cli(an_anonymize_mock):
+    sys.argv = ['cmd', 'input', 'output']
+    main()
+    an_anonymize_mock.assert_called_once_with("input", "output", {}, True)
+
+
+def test_simple_tag_arguments(an_anonymize_mock):
+    sys.argv = ['cmd', 'input', 'output', '-t', '(0x0010, 0x0010)', 'empty']
+    main()
+    an_anonymize_mock.assert_called_once_with("input", "output", {(0x0010, 0x0010): empty}, True)
+
+
+def test_complex_tag_arguments(an_anonymize_mock, a_simple_dataset):
+    sys.argv = ['cmd', 'input', 'output', '-t', '(0x0010, 0x0010)', 'replace_with_value', 'Replaced']
+    main()
+    # Call the function created by our arguments to make sure it works as expected
+    an_anonymize_mock.call_args.args[2][(0x0010, 0x0010)](a_simple_dataset, (0x0010, 0x0010))
+    assert a_simple_dataset[(0x0010, 0x0010)].value == "Replaced"
+
+
+@patch("builtins.open")
+def test_dictionnay_argument(an_open_mock, an_anonymize_mock):
+    class FakeFile:
+        def read(self):
+            return '{"(0x0010, 0x0010)": "empty"}'
+
+    an_open_mock.return_value.__enter__.return_value = FakeFile()
+    sys.argv = ['cmd', 'input', 'output', '--dictionary', 'whatever.json']
+    main()
+    an_anonymize_mock.assert_called_once_with("input", "output", {(0x0010, 0x0010): empty}, True)
+
+
+@patch("builtins.open")
+def test_complex_dictionnary_argument(an_open_mock, an_anonymize_mock, a_simple_dataset):
+    class FakeFile:
+        def read(self):
+            return '{"(0x0010, 0x0010)": {"action":"regexp", "find": "Name", "replace": "Replaced"}}'
+
+    an_open_mock.return_value.__enter__.return_value = FakeFile()
+    sys.argv = ['cmd', 'input', 'output', '--dictionary', 'whatever.json']
+    main()
+    # Call the function created by our arguments to make sure it works as expected
+    an_anonymize_mock.call_args.args[2][(0x0010, 0x0010)](a_simple_dataset, (0x0010, 0x0010))
+    assert a_simple_dataset[(0x0010, 0x0010)].value == "Test Replaced"
+
+
+def test_unrecognized_action_gives_helpful_error():
+    sys.argv = ['cmd', 'input', 'output', '-t', '(0x0010, 0x0010)', 'wrong_action']
+    try:
+        main()
+    except ValueError as e:
+        assert "not recognized" in str(e)
+
+
+def test_wrong_number_of_arguments_gives_helpful_error():
+    sys.argv = ['cmd', 'input', 'output', '-t', '(0x0010, 0x0010)', 'replace_with_value']
+    try:
+        main()
+    except ValueError as e:
+        assert "number of arguments" in str(e)


### PR DESCRIPTION
- Remove the calls to `eval` with a user input that were a big security flaw
- Refactor CLI system to add new actions easily
- Add a `replace_with_value` action
- Add tests
- Do house cleaning (fix formating, replace type comparison with isinstance, fix imports)