### PR TITLE
GitHub actions to cover python versions 3.8 to 3.11

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -5,14 +5,20 @@ on:
 jobs:
   launch-unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Tracked via issue #77
+        # 3.6: Not available on ubuntu-22.04
+        # 3.7: Results in failures in `test_cli.py`
+        # 3.12: pkg_resources not supported
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.3'
-          cache: 'pip'
-          cache-dependency-path: setup.py
+          python-version: ${{ matrix.python-version }}
       - run: python -m venv env
       - run: source env/bin/activate
       - run: env/bin/pip install -e .


### PR DESCRIPTION
- Tested python 3.8, 3.9, 3.10, and 3.11
- Added remaining versions of python as TODO in Task #77 